### PR TITLE
BUGFIX: Prevent exception

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,36 +5,39 @@ call_user_func(function () {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output'][] =
         'EXT:email2powermail/Classes/Hooks/ContentPostProc.php:' .
         '&In2code\\Email2powermail\\Hooks\\ContentPostProc->manipulateOutput';
-    
-    # Use signals
-    $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-        \TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class
-    );
 
-    // Manipulate email before sending example
-    $signalSlotDispatcher->connect(
-        \In2code\Powermail\Domain\Service\ReceiverEmailService::class,
-        'setReceiverEmails',
-        \In2code\Email2powermail\Slots\ReceiverEmailService::class,
-        'setReceiverEmails',
-        false
-    );
+    $pluginVariables = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('tx_email2powermail');
+    if (isset($pluginVariables['id'])) {
+        # Use signals
+        $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+            \TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class
+        );
 
-    // Manipulate name before sending example
-    $signalSlotDispatcher->connect(
-        \In2code\Powermail\Domain\Service\ReceiverEmailService::class,
-        'getReceiverName',
-        \In2code\Email2powermail\Slots\ReceiverEmailService::class,
-        'getReceiverName',
-        false
-    );
+        // Manipulate email before sending example
+        $signalSlotDispatcher->connect(
+            \In2code\Powermail\Domain\Service\ReceiverEmailService::class,
+            'setReceiverEmails',
+            \In2code\Email2powermail\Slots\ReceiverEmailService::class,
+            'setReceiverEmails',
+            false
+        );
 
-    // Add own markers
-    $signalSlotDispatcher->connect(
-        \In2code\Powermail\Domain\Repository\MailRepository::class,
-        'getVariablesWithMarkersFromMail',
-        \In2code\Email2powermail\Slots\MarkerSlot::class,
-        'getVariablesWithMarkersFromMail',
-        false
-    );
+        // Manipulate name before sending example
+        $signalSlotDispatcher->connect(
+            \In2code\Powermail\Domain\Service\ReceiverEmailService::class,
+            'getReceiverName',
+            \In2code\Email2powermail\Slots\ReceiverEmailService::class,
+            'getReceiverName',
+            false
+        );
+
+        // Add own markers
+        $signalSlotDispatcher->connect(
+            \In2code\Powermail\Domain\Repository\MailRepository::class,
+            'getVariablesWithMarkersFromMail',
+            \In2code\Email2powermail\Slots\MarkerSlot::class,
+            'getVariablesWithMarkersFromMail',
+            false
+        );
+    }
 });


### PR DESCRIPTION
When submitting a powermail form on a page not matching plugin.tx_email2powermail.settings.pid
an exception in thrown:

Call to a member function toArray() on null in email2powermail/Classes/Slots/MarkerSlot.php in line 26